### PR TITLE
Martin formula updated

### DIFF
--- a/HomebrewFormula/martin.rb
+++ b/HomebrewFormula/martin.rb
@@ -1,10 +1,10 @@
 class Martin < Formula
-  current_version="0.5.0"
+  current_version="0.6.2"
 
   desc "PostGIS Mapbox Vector Tiles server"
   homepage "https://github.com/urbica/martin"
   url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
-  sha256 "b80a97912e1c084e878dd89e979bfbd2525f8db95efa67b33a0c5b3d34783f29"
+  sha256 "57cc5b94def70ad51ffa499ddb70a31545e26fa3d24865caa139a960994477be"
   version "#{current_version}"
 
   def install

--- a/HomebrewFormula/martin.rb
+++ b/HomebrewFormula/martin.rb
@@ -3,9 +3,21 @@ class Martin < Formula
 
   desc "PostGIS Mapbox Vector Tiles server"
   homepage "https://github.com/urbica/martin"
-  url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
-  sha256 "57cc5b94def70ad51ffa499ddb70a31545e26fa3d24865caa139a960994477be"
+  #url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
+  url "https://github.com/urbica/martin/archive/refs/tags/v#{current_version}.tar.gz"
+  sha256 "ce7ce46ca3006cf7dcad84ef526f3d96934c34211c9c199b79839458f4fa463f"
   version "#{current_version}"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
+      sha256 "57cc5b94def70ad51ffa499ddb70a31545e26fa3d24865caa139a960994477be"
+    end
+    on_arm do
+      url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-aarch64.tar.gz"
+      sha256 "f1d6edfa92ef52f9509cccc167c96caced0f344f78c55976de56aa30dc191114"
+    end
+  end
 
   def install
     bin.install "martin"

--- a/HomebrewFormula/martin.rb
+++ b/HomebrewFormula/martin.rb
@@ -1,21 +1,21 @@
 class Martin < Formula
-  current_version="0.6.2"
+  current_version="0.7.2"
 
   desc "PostGIS Mapbox Vector Tiles server"
   homepage "https://github.com/urbica/martin"
   #url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
   url "https://github.com/urbica/martin/archive/refs/tags/v#{current_version}.tar.gz"
-  sha256 "ce7ce46ca3006cf7dcad84ef526f3d96934c34211c9c199b79839458f4fa463f"
+  sha256 "6072b05812fe444788db236513b43974c340c02ca97a43efac7d193c57a15be0"
   version "#{current_version}"
 
   on_macos do
     on_intel do
       url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
-      sha256 "57cc5b94def70ad51ffa499ddb70a31545e26fa3d24865caa139a960994477be"
+      sha256 "82aba9100a2d58ca40edf6ebd75199f62b24eff845115b8cb503d706a0529326"
     end
     on_arm do
       url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-aarch64.tar.gz"
-      sha256 "f1d6edfa92ef52f9509cccc167c96caced0f344f78c55976de56aa30dc191114"
+      sha256 "58326f116bfa331dee6062a80f68364ddfedcf36412fe144fd0578d8f0a7a386"
     end
   end
 

--- a/HomebrewFormula/martin.rb
+++ b/HomebrewFormula/martin.rb
@@ -1,21 +1,20 @@
 class Martin < Formula
-  current_version="0.7.2"
+  current_version="0.8.1"
 
   desc "PostGIS Mapbox Vector Tiles server"
   homepage "https://github.com/urbica/martin"
-  #url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
   url "https://github.com/urbica/martin/archive/refs/tags/v#{current_version}.tar.gz"
-  sha256 "6072b05812fe444788db236513b43974c340c02ca97a43efac7d193c57a15be0"
+  sha256 "95dfa5c600a33118a0e712f17eb76cac2fdcea4fd90a8afff98a3173e763b0cf"
   version "#{current_version}"
 
   on_macos do
     on_intel do
       url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-x86_64.tar.gz"
-      sha256 "82aba9100a2d58ca40edf6ebd75199f62b24eff845115b8cb503d706a0529326"
+      sha256 "554171bc4761c1852f0d6509b16af00d67f2d2b7d78ad20d9f819beb5d967e8a"
     end
     on_arm do
       url "https://github.com/urbica/martin/releases/download/v#{current_version}/martin-Darwin-aarch64.tar.gz"
-      sha256 "58326f116bfa331dee6062a80f68364ddfedcf36412fe144fd0578d8f0a7a386"
+      sha256 "f4b30b228e747c72f8690b93d0a85a0bad7ea963c0d3e2b475147d94a0ac632c"
     end
   end
 


### PR DESCRIPTION
* updated to latest stable version (v0.6.2)
* added support for aarch64 so this formula can work on newer macs